### PR TITLE
✨ feat: add declarative pipeline stages functionality

### DIFF
--- a/jupyter/01-playground.ipynb
+++ b/jupyter/01-playground.ipynb
@@ -137,7 +137,7 @@
     "    stages = [\n",
     "        TimesThreeStage(),\n",
     "        my_pipeline,\n",
-    "        AddFiveStage(),\n",
+    "        AddFiveStage,\n",
     "    ]\n",
     "\n",
     "await MyPipeline().process(5)"

--- a/src/thecodecrate_pipeline/classes/pipeline.py
+++ b/src/thecodecrate_pipeline/classes/pipeline.py
@@ -9,6 +9,9 @@ from ..partials.with_base.pipeline import (
 from ..partials.with_pipeline_as_list.pipeline_mixin import (
     PipelineMixin as WithPipelineAsListConcern,
 )
+from ..partials.with_pipeline_declared_stages.pipeline_mixin import (
+    PipelineMixin as WithPipelineDeclaredStagesConcern,
+)
 from ..partials.with_pipeline_processor.pipeline_mixin import (
     PipelineMixin as WithPipelineProcessorConcern,
 )
@@ -28,6 +31,7 @@ class Pipeline(
     WithPipelineAsImmutableConcern[TPayload],
     WithPipelineAsStageConcern[TPayload],
     WithPipelineProcessorConcern[TPayload],
+    WithPipelineDeclaredStagesConcern[TPayload],
     WithPipelineAsListConcern[TPayload],
     WithPipelineBaseConcern,
     ImplementsPipelineInterface[TPayload],

--- a/src/thecodecrate_pipeline/classes/pipeline_interface.py
+++ b/src/thecodecrate_pipeline/classes/pipeline_interface.py
@@ -7,6 +7,9 @@ from ..partials.with_base.pipeline_interface import (
 from ..partials.with_pipeline_as_list.pipeline_interface_mixin import (
     PipelineInterfaceMixin as WithPipelineAsListInterface,
 )
+from ..partials.with_pipeline_declared_stages.pipeline_interface_mixin import (
+    PipelineInterfaceMixin as WithPipelineDeclaredStagesInterface,
+)
 from ..partials.with_pipeline_processor.pipeline_interface_mixin import (
     PipelineInterfaceMixin as WithPipelineProcessorInterface,
 )
@@ -26,6 +29,7 @@ class PipelineInterface(
     WithPipelineAsImmutableInterface[TPayload],
     WithPipelineAsStageInterface[TPayload],
     WithPipelineProcessorInterface[TPayload],
+    WithPipelineDeclaredStagesInterface[TPayload],
     WithPipelineAsListInterface[TPayload],
     WithPipelineBaseInterface,
     Protocol[TPayload],

--- a/src/thecodecrate_pipeline/partials/with_pipeline_as_list/pipeline_mixin.py
+++ b/src/thecodecrate_pipeline/partials/with_pipeline_as_list/pipeline_mixin.py
@@ -15,12 +15,12 @@ class PipelineMixin(
     ImplementsPipelineInterface[TPayload],
     Protocol[TPayload],
 ):
-    stages: list[PipelineCallable[TPayload, ...]] = []
+    stage_instances: list[PipelineCallable[TPayload, ...]] = []
 
     def get_items(self) -> list[PipelineCallable[TPayload, ...]]:
-        return self.stages
+        return self.stage_instances
 
     def set_items(self, items: list[PipelineCallable[TPayload, ...]]) -> Self:
-        self.stages = items
+        self.stage_instances = items
 
         return self

--- a/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/pipeline_interface_mixin.py
+++ b/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/pipeline_interface_mixin.py
@@ -1,0 +1,17 @@
+from typing import Protocol
+
+from ..with_base.type_payload import TPayload
+from ..with_pipeline_as_list.pipeline_interface_mixin import (
+    PipelineInterfaceMixin as WithPipelineAsListInterface,
+)
+from ..with_base.pipeline_interface import (
+    PipelineInterface as WithPipelineBaseInterface,
+)
+
+
+class PipelineInterfaceMixin(
+    WithPipelineAsListInterface[TPayload],
+    WithPipelineBaseInterface,
+    Protocol[TPayload],
+):
+    def _instantiate_stages(self) -> None: ...

--- a/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/pipeline_mixin.py
+++ b/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/pipeline_mixin.py
@@ -1,0 +1,39 @@
+from typing import Any, Generic
+
+from thecodecrate_pipeline.partials.with_base.type_pipeline_callable import (
+    PipelineCallable,
+)
+
+from .stage_facade import StageFacade
+from .pipeline_interface_mixin import (
+    PipelineInterfaceMixin as ImplementsPipelineInterface,
+)
+from ..with_base.type_payload import TPayload
+
+PipelineCallableOrStage = (
+    type[StageFacade[TPayload]]
+    | StageFacade[TPayload]
+    | PipelineCallable[TPayload, ...]
+)
+
+
+class PipelineMixin(
+    ImplementsPipelineInterface[TPayload],
+    Generic[TPayload],
+):
+    stages: list[PipelineCallableOrStage[TPayload]] = []
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwds: Any,
+    ) -> None:
+        super().__init__(*args, **kwds)
+
+        self._instantiate_stages()
+
+    def _instantiate_stages(self) -> None:
+        self.stage_instances = [
+            stage() if isinstance(stage, type) else stage
+            for stage in self.stages
+        ]

--- a/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/stage_facade.py
+++ b/src/thecodecrate_pipeline/partials/with_pipeline_declared_stages/stage_facade.py
@@ -1,0 +1,17 @@
+from typing import Protocol
+
+from ..with_base.type_payload import TPayload
+from ..with_base.stage_interface import (
+    StageInterface as WithStageBaseInterface,
+)
+from ..with_stage_as_callable.stage_interface_mixin import (
+    StageInterfaceMixin as WithStageAsCallableInterface,
+)
+
+
+class StageFacade(
+    WithStageAsCallableInterface[TPayload],
+    WithStageBaseInterface,
+    Protocol[TPayload],
+):
+    pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -120,13 +120,24 @@ async def test_interruptible_processor():
 
 @pytest.mark.asyncio
 async def test_declarative_stages():
+    pipeline = (Pipeline[int]()).pipe(TimesTwoStage()).pipe(AddOneStage())
+
+    def add_seven(payload: int) -> int:
+        return payload + 7
+
+    async def sub_three_async(payload: int) -> int:
+        return payload - 3
+
     class MyPipeline(Pipeline[int]):
         stages = [
-            TimesTwoStage(),
-            TimesThreeStage(),
+            TimesThreeStage(),  # stage instance
+            pipeline,  # pipeline
+            AddOneStage,  # stage class
+            add_seven,  # function
+            sub_three_async,  # async function
         ]
 
-    assert await MyPipeline().process(5) == 30
+    assert await MyPipeline().process(5) == 36
 
 
 @pytest.mark.asyncio
@@ -134,8 +145,8 @@ async def test_declarative_stages_with_processor():
     class MyPipeline(Pipeline[int]):
         processor_class = StubProcessor
         stages = [
-            TimesTwoStage(),
-            TimesThreeStage(),
+            TimesTwoStage,
+            TimesThreeStage,
         ]
 
     assert await MyPipeline().process(5) == 300


### PR DESCRIPTION
Implemented support for declarative pipeline stages. Users can now define stages using instances, classes, functions (sync/async), or pipelines directly in the `stages` property.

Refactored the `stages` property into `stage_instances` and introduced the `with_pipeline_declared_stages` partial to instantiate stage classes automatically.