### PR TITLE
:recycle: refactor: extract command instance creation into a separate…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thecodecrate-pipeline"
-version = "1.18.0"
+version = "1.19.0"
 description = "This package provides a pipeline pattern implementation"
 readme = "README.md"
 authors = [{ name = "TheCodeCrate", email = "loureiro.rg@gmail.com" }]
@@ -42,7 +42,7 @@ repository = "https://github.com/thecodecrate/python-pipeline"
 documentation = "https://github.com/thecodecrate/python-pipeline"
 
 [tool.bumpver]
-current_version = "1.18.0"
+current_version = "1.19.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "🚀 feat: bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/src/thecodecrate_pipeline/__init__.py
+++ b/src/thecodecrate_pipeline/__init__.py
@@ -84,7 +84,7 @@ from .partials.with_processor_commands.traits.processable_as_command import (
 # This will be updated by `bumpver` command.
 # - Make sure to commit all changes first before running `bumpver`.
 # - Run `bumpver update --[minor|major|patch]`
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 
 # Expose the public API
 __all__ = [

--- a/src/thecodecrate_pipeline/partials/with_processor_commands/strategies/command_processing_strategy.py
+++ b/src/thecodecrate_pipeline/partials/with_processor_commands/strategies/command_processing_strategy.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ..command_interface import CommandInterface
 from ...with_base.stage_callable import StageCallable
 from ...with_base.types import T_in, T_out
 from ..processing_strategy import ProcessingStrategy
@@ -13,15 +14,24 @@ class CommandProcessingStrategy(ProcessingStrategy[T_in, T_out]):
         *args: Any,
         **kwds: Any,
     ) -> T_out:
+        command = self._make_command(payload, stages, *args, **kwds)
+
+        return await command.execute(*args, **kwds)
+
+    def _make_command(
+        self,
+        payload: T_in,
+        stages: list[StageCallable],
+        *args: Any,
+        **kwds: Any,
+    ) -> CommandInterface[T_in, T_out]:
         if not self.processor.command_class:
             raise ValueError("Command class is not set")
 
-        command = self.processor.command_class(
+        return self.processor.command_class(
             processor=self.processor,
             payload=payload,
             stages=stages,
             *args,
             **kwds,
         )
-
-        return await command.execute(*args, **kwds)


### PR DESCRIPTION
… method

- Refactored `CommandProcessingStrategy` to extract the command instance creation logic into a dedicated method `_make_command`.
- Improved code readability and maintainability by separating concerns within the processing strategy.
- The `_make_command` method now handles instantiation of the command, allowing better customization and reuse.